### PR TITLE
#9 [Feature] - Implement localStorage to save the temp-cart items

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -10,6 +10,34 @@ type CardProps = {
 
 // Render Card component.
 const Card = ({title, subtitle, ctaText, imageUrl} : CardProps) => {
+    
+    // Save item to localStorage to be displayed on Cart.
+    const addToCart = () => {
+        let storage = localStorage.getItem('orders');
+        if (storage) {
+            // Parsing the localStorage into JS Object.
+            let storedCart : string[] = JSON.parse(storage);
+
+            // Push new item to storedCart.
+            storedCart.push(title);
+
+            // Save back the localStorage.
+            localStorage.setItem('orders', JSON.stringify(storedCart));
+        } else {
+            // Create new localStorage item called orders.
+            let orders : string[] = [];
+
+            // Push new item to storedCart.
+            orders.push(title);
+
+            // Save back the localStorage.
+            localStorage.setItem('orders', JSON.stringify(orders));
+        }
+
+        window.location.reload();
+    }
+
+    // Render.
     return (
         <div className='rounded-xl relative'>
             {/* Overlay */}
@@ -17,6 +45,7 @@ const Card = ({title, subtitle, ctaText, imageUrl} : CardProps) => {
                 <p className='font-bold text-xl px-3 pt-4'>{title}</p>
                 <p className='px-3'>{subtitle}</p>
                 <button 
+                    onClick={addToCart}
                     className='absolute border-white bg-white text-black mx-3 bottom-4 rounded-full py-2 hover:bg-transparent hover:text-white duration-500'
                 >
                     {ctaText}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { AiOutlineMenu } from "react-icons/ai";
 import { BsFillCartFill } from "react-icons/bs";
 import { Link } from "react-router-dom";
@@ -17,6 +17,18 @@ const defaultBrandProp = {
 const Navbar = ({brand} : typeof defaultBrandProp) => {
   // Manage Sidebar menu state.
   const [showNav, setShowNav] = useState<boolean>(false);
+
+  // Manage Cart amount.
+  const [cartNo, setCartNo] = useState<number>(0);
+
+  // Fetch Cart amount from localStorage if any.
+  useEffect(() => {
+    let storage = localStorage.getItem('orders');
+    if (storage) {
+      const orders : string[] = JSON.parse(storage);
+      setCartNo(orders.length);
+    }
+  }, [cartNo]);
 
   return (
     <div className="max-w-[1640px] mx-auto flex justify-between items-center p-4">
@@ -42,9 +54,10 @@ const Navbar = ({brand} : typeof defaultBrandProp) => {
       {/* Cart Menu */}
       <div className="bg-black text-white rounded-full py-2">
         <Link to={`/orders`}>
-          <button className="flex items-center gap-x-2 border-none">
+          <button className="flex items-center gap-x-1 border-none">
             <BsFillCartFill />
-            <span className="hidden lg:block">Cart</span>
+            <span className="hidden lg:inline">Cart</span>
+            {cartNo > 0 && <span>{`(${cartNo})`}</span>}
           </button>
         </Link>
       </div>


### PR DESCRIPTION
### Description

- [x] Create a localStorage with key "orders" which save the title of food being added to cart (temporarily)
- [x] Fetch the localStorage items and update the Cart button on nav to display the no-of-cart-items added
- [x] If localStorage is 0, then we don't display the no-of-cart-items on the Cart button
- [x] Reload the page per added item
- [x] The localStorage will preload the no-of-cart-items even after window close (persist)

### Note
Another solution is to implement redux or central state management, so we can immediately update the CART button when state changes.

Currently, this solution does not yet implement Redux, hence, I need to force `window.location.reload()` per item-added.

### Testing

Test passed ✅ 

- The Cart button gets updated per item added
- The order now button adds item to localStorage

https://user-images.githubusercontent.com/31334333/193766309-80de0539-2843-4bef-aae5-cff7601485ee.mov
