### PR TITLE
[Fix] - Remove orders from effect's dependency-list causing infinite re-rendering

### DIFF
--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -16,7 +16,7 @@ const Orders = () => {
         if (storage) {
             setOrders(JSON.parse(storage));
         }
-    }, [orders]);
+    }, []);
 
     // Remove item from orders localStorage.
     const removeFromCart = (index: number) => {


### PR DESCRIPTION
### Description

Bug described as per ticket:
- [x]  #14 

#### Reproduction Steps
1. Add item to cart by clicking any of the Order Now button.
2. Click on Cart on Navbar or go to Sidebar Menu and click Orders.
3. On console, you should start seeing the error as the component will be infinitely re-rendering.

#### Issue
Err found `maximum update depth exceed` which was caused by the following useEffect in Orders page to depend on itself, causing the component to be infinitely re-render (infinite loop).

#### Solution

- Remove `orders` from dependency-array

It simply means that the hook will only trigger once when the component is first rendered. So for example, for useEffect it means the callback will run once at the beginning of the lifecycle of the component (when first mount).

The `useEffect()` here will still fetch from the localStorage for any order-item added.

Removing the item from order-list is handled by `removeFromCart()` and this change won't have impact on this feature.

### Testing

Fix has been re-tested.

Result: Test Passed ✅ 


https://user-images.githubusercontent.com/31334333/194225326-f1b787c0-bddc-459d-beda-aaf8f89502a2.mov

